### PR TITLE
fix: editing input validation functions - 3

### DIFF
--- a/src/pages/index.scss
+++ b/src/pages/index.scss
@@ -296,5 +296,5 @@ $border-focus-color: rgba(0, 0, 0, 1);
   font-family: $font-funnel-sans;
   font-weight: 400;
   font-size: 16px;
-  line-height: 20px;
+  line-height: 1.25;
 }


### PR DESCRIPTION
Исправлены проблемы:
1) Если после запятой ввести цифры, а потом стереть их, оставив запятую (10,9 => 10,) - курс обмена не изменится
2) Если через правую кнопку мыши вставить в поле буквы/знаки - в результат подставится 0 и под инпутами выведет "1=1"
3) Можно было вводить несколько нулей до запятой